### PR TITLE
Fixes issue #18

### DIFF
--- a/src/java/com/opensymphony/module/sitemesh/factory/DefaultFactory.java
+++ b/src/java/com/opensymphony/module/sitemesh/factory/DefaultFactory.java
@@ -143,7 +143,7 @@ public class DefaultFactory extends BaseFactory {
             is = config.getServletContext().getResourceAsStream(configFileName);
         }
         else if (configFile.exists() && configFile.canRead()) {
-            is = configFile.toURL().openStream();
+            is = configFile.toURI().toURL().openStream();
         }
 
         if (is == null){ // load the default sitemesh configuration
@@ -181,7 +181,7 @@ public class DefaultFactory extends BaseFactory {
             is = config.getServletContext().getResourceAsStream(excludesFileName);
         }
         else if (excludesFile.exists() && excludesFile.canRead()) {
-            is = excludesFile.toURL().openStream();
+            is = excludesFile.toURI().toURL().openStream();
         }
 
         if (is == null){


### PR DESCRIPTION
This commit fixes issue #18. It just replaces the use of the deprecated File.toURL() with the suggested File.toURI().toURL().
This allows sitemesh to find the configuration file in cases when the war file contains, for example, the '#' character (useful in tomcat to deploy to a subfolder).
