### PR TITLE
support for decorator:div tag

### DIFF
--- a/src/etc/tld/jsp1.2/sitemesh-decorator.tld
+++ b/src/etc/tld/jsp1.2/sitemesh-decorator.tld
@@ -36,6 +36,17 @@
     </tag>
 
     <tag>
+        <name>div</name>
+        <tag-class>com.opensymphony.module.sitemesh.taglib.decorator.DivTag</tag-class>
+        <body-content>JSP</body-content>
+        <attribute>
+            <name>id</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+
+    <tag>
         <name>getProperty</name>
         <tag-class>com.opensymphony.module.sitemesh.taglib.decorator.PropertyTag</tag-class>
         <body-content>JSP</body-content>

--- a/src/etc/tld/sitemesh-decorator.tld
+++ b/src/etc/tld/sitemesh-decorator.tld
@@ -32,6 +32,17 @@
 	</tag>
 
 	<tag>
+	<name>div</name>
+		<tag-class>com.opensymphony.module.sitemesh.taglib.decorator.DivTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>id</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+
+	<tag>
 		<name>getProperty</name>
 		<tagclass>com.opensymphony.module.sitemesh.taglib.decorator.PropertyTag</tagclass>
 		<bodycontent>JSP</bodycontent>
@@ -50,7 +61,7 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-    </tag>
+	</tag>
 
 	<tag>
 		<name>extractProperty</name>

--- a/src/java/com/opensymphony/module/sitemesh/multipass/DivExtractingPageParser.java
+++ b/src/java/com/opensymphony/module/sitemesh/multipass/DivExtractingPageParser.java
@@ -31,7 +31,11 @@ public class DivExtractingPageParser extends HTMLPageParser {
                     currentBuffer().append("<sitemesh:multipass id=\"div." + id + "\"/>");
                     blockId = id;
                     context.pushBuffer(new CharArray(512));
-                }
+
+                    for (int i = 0; i < tag.getAttributeCount(); i++) {
+                        page.addProperty(String.format("div.%s.%s", blockId, tag.getAttributeName(i)), tag.getAttributeValue(i));
+                    }
+                  }
                 tag.writeTo(currentBuffer());
                 depth++;
             } else if (tag.getType() == Tag.CLOSE) {

--- a/src/java/com/opensymphony/module/sitemesh/taglib/decorator/DivTag.java
+++ b/src/java/com/opensymphony/module/sitemesh/taglib/decorator/DivTag.java
@@ -1,0 +1,52 @@
+/*
+ * Title:        DivTag
+ * Description:
+ *
+ * This software is published under the terms of the OpenSymphony Software
+ * License version 1.1, of which a copy has been included with this
+ * distribution in the LICENSE.txt file.
+ */
+
+package com.opensymphony.module.sitemesh.taglib.decorator;
+
+import java.io.IOException;
+
+import javax.servlet.jsp.JspException;
+
+import com.opensymphony.module.sitemesh.HTMLPage;
+import com.opensymphony.module.sitemesh.taglib.AbstractTag;
+
+/**
+ * Write a HTMLPage div to out.
+ *
+ * @author mouyang
+ * @version $Revision: 1.3 $
+ *
+ * @see com.opensymphony.module.sitemesh.HTMLPage#writeHead(java.io.Writer)
+ */
+public class DivTag extends AbstractTag {
+    protected String divId;
+
+    public String getId() {
+        return divId;
+    }
+
+    public void setId(String divId) {
+        this.divId = divId;
+    }
+    public final int doEndTag() throws JspException
+    {
+      try
+      {
+        String divBody = getPage().getProperty("div." + divId);
+        if (divBody != null) {
+          getOut().write(divBody.substring(divBody.indexOf('>') + 1, divBody.lastIndexOf('<')));
+        }
+      }
+      catch(IOException e)
+      {
+        throw new JspException("Error writing head element: " + e.toString(), e);
+      }
+      return EVAL_PAGE;
+    }
+}

--- a/src/test/com/opensymphony/module/sitemesh/multipass/DivExtractingPageParserTest.java
+++ b/src/test/com/opensymphony/module/sitemesh/multipass/DivExtractingPageParserTest.java
@@ -38,5 +38,24 @@ public class DivExtractingPageParserTest extends TestCase {
         assertEquals("<div id='two'>World<br><div id=inner>Great</div></div>", page.getProperty("div.two"));
     }
 
+    public void testExtractAttributes() throws IOException {
+        String input = "" +
+                "<html>\n" +
+                "  <head><title>Title</title></head>\n" +
+                "  <body>\n" +
+                "    <div id='one' class='c_one' align='center'>Hello</div>\n" +
+                "    Blah\n" +
+                "    <div id='two'>World<br><div id=inner>Great</div></div>\n" +
+                "    <div>Bye</div>\n" +
+                "  </body>\n" +
+                "</html>";
+
+        PageParser parser = new DivExtractingPageParser();
+        Page page = parser.parse(input.toCharArray());
+
+        assertEquals("c_one", page.getProperty("div.one.class"));
+        assertEquals("center", page.getProperty("div.one.align"));
+        assertEquals("two", page.getProperty("div.two.id"));
+    }
 }
 


### PR DESCRIPTION
This allowed decorators to grab text from a particular div on the original page.  This was not possible previously because there was only tags for head, title and body.
