### PR TITLE
Weblogic 10.3.5 unable to find excludesFile path using getResourceAsStream

### DIFF
--- a/src/java/com/opensymphony/module/sitemesh/factory/DefaultFactory.java
+++ b/src/java/com/opensymphony/module/sitemesh/factory/DefaultFactory.java
@@ -179,6 +179,11 @@ public class DefaultFactory extends BaseFactory {
 
         if (excludesFile == null) {
             is = config.getServletContext().getResourceAsStream(excludesFileName);
+            String excludesFilePath = config.getServletContext().getRealPath(excludesFileName);//getResourceAsStream does not work on weblogic 10.3.5
+            if (excludesFilePath != null) { 
+            	excludesFile = new File(excludesFilePath);
+            	is = excludesFile.toURL().openStream();
+            }
         }
         else if (excludesFile.exists() && excludesFile.canRead()) {
             is = excludesFile.toURL().openStream();


### PR DESCRIPTION
While working on a project to upgrade from oracle application server to Weblogic 10.3.5 I ran into an issue where Weblogic was not able to find excludes file in the default location (/WEB-INF/lib/decorators.xml) using "getResourceAsStream"; 
Using "getRealPath" worked for me. 
I still have not been able to figure out exactly how Weblogic creates its application structures or have not really tried out all different options, but was successful with that change.
