### PR TITLE
fix rendering for script/comment/CDATA inside content tags in FastPageParser.java

### DIFF
--- a/src/java/com/opensymphony/module/sitemesh/parser/FastPageParser.java
+++ b/src/java/com/opensymphony/module/sitemesh/parser/FastPageParser.java
@@ -153,6 +153,32 @@ public final class FastPageParser implements PageParser
                   _currentTaggedContent.append('<').append(_buffer).append('>');
                }
             }
+            else if (_tokenType == TOKEN_COMMENT)
+            {
+               if(_buffer.length() > 0)
+               {
+                  _currentTaggedContent.append("<!--");
+                  _currentTaggedContent.append(_buffer);
+                  _currentTaggedContent.append("-->");
+               }
+            }
+            else if (_tokenType == TOKEN_CDATA)
+            {
+               if(_buffer.length() > 0)
+               {
+                  _currentTaggedContent.append("<![CDATA[");
+                  _currentTaggedContent.append(_buffer);
+                  _currentTaggedContent.append("]]>");
+               }
+            }
+            else if (_tokenType == TOKEN_SCRIPT)
+            {
+               if(_buffer.length() > 0)
+               {
+                  _currentTaggedContent.append('<');
+                  _currentTaggedContent.append(_buffer);
+               }
+            }
             else
             {
                if(_buffer.length() > 0) _currentTaggedContent.append(_buffer);


### PR DESCRIPTION
fix script/CDATA/comment rendering inside of content tag.

reference:
https://jira.atlassian.com/browse/CONF-16098
https://jira.atlassian.com/browse/JRA-16503

Details:
we fixed the output to _buffer while in content tag (tagged = true)

behavior before fix:
<content tag="...">

<!--comment-->

<script src="...">
<![CDATA[MyData]]>
<!--<--><script src="...">       ;-)
</content>

rendered to (leading '<' is missing, comment is no comment anymore, CDATA not quoted)

<content tag="...">
comment
script src="...">
MyData
<script src="...">
</content>

after fix rendered to:

<content tag="...">

<!--comment-->

<script src="...">
<![CDATA[MyData]]>
<!--<--><script src="...">
</content>

sorry, no tests written.
